### PR TITLE
[Core] Add Json Schema generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ dependencies = [
  "pastey",
  "petgraph",
  "scanf",
+ "schemars",
  "serde",
  "serde-big-array",
  "string-interner",
@@ -697,6 +698,7 @@ dependencies = [
  "indicatif",
  "pathdiff",
  "rayon",
+ "schemars",
  "serde_json",
  "shadow-rs",
 ]
@@ -1507,6 +1509,12 @@ name = "dpi"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecolor"
@@ -3667,6 +3675,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3803,6 +3831,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "indexmap",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3857,10 +3911,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.138"
+name = "serde_derive_internals"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",

--- a/bff-cli/Cargo.toml
+++ b/bff-cli/Cargo.toml
@@ -14,6 +14,7 @@ derive_more = { version = "2.0.1", features = ["full"] }
 indicatif = "0.17.11"
 pathdiff = "0.2.1"
 rayon = "1.10.0"
+schemars = "1.0.4"
 serde_json = "1.0.96"
 shadow-rs = { version = "1.1.1", default-features = false, features = ["build"] }
 

--- a/bff-cli/src/dump_json_schema.rs
+++ b/bff-cli/src/dump_json_schema.rs
@@ -1,0 +1,18 @@
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::Path;
+
+use bff::bigfile::resource::BffClass;
+use schemars::schema_for;
+
+use crate::error::BffCliResult;
+
+pub fn dump_json_schema(path: &Path) -> BffCliResult<()> {
+    let json_schema_writer = BufWriter::new(File::create(path)?);
+
+    let schema = schema_for!(BffClass);
+
+    serde_json::to_writer_pretty(json_schema_writer, &schema)?;
+
+    Ok(())
+}

--- a/bff-cli/src/extract.rs
+++ b/bff-cli/src/extract.rs
@@ -193,7 +193,7 @@ pub fn extract(
     let bigfile = read_bigfile(bigfile_path, platform_override, version_override)?;
 
     progress_bar.set_message("Writing manifest");
-    std::fs::create_dir(directory)?;
+    std::fs::create_dir_all(directory)?;
 
     let manifest_path = directory.join("manifest.json");
     let manifest_writer = BufWriter::new(File::create(manifest_path)?);

--- a/bff-cli/src/main.rs
+++ b/bff-cli/src/main.rs
@@ -15,6 +15,7 @@ mod crc;
 mod create;
 mod create_resource;
 mod csc;
+mod dump_json_schema;
 mod error;
 mod extract;
 mod extract_resource;
@@ -205,6 +206,8 @@ enum Commands {
     },
     #[clap(alias = "tyb")]
     TryYourBest { path: PathBuf },
+    #[clap(alias = "djs")]
+    DumpJsonSchema { path: PathBuf },
 }
 
 #[derive(Parser)]
@@ -340,5 +343,6 @@ fn main() -> BffCliResult<()> {
             lin,
         } => fat_lin::create_fat_lin(directory, fat, lin),
         Commands::TryYourBest { path } => try_your_best::try_your_best(path),
+        Commands::DumpJsonSchema { path } => dump_json_schema::dump_json_schema(path),
     }
 }

--- a/bff/Cargo.toml
+++ b/bff/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1.18.0"
 pastey = "0.1.0"
 petgraph = "0.8.1"
 scanf = "1.2.1"
+schemars = { version = "1.0.4", features = ["indexmap2"] }
 serde = { version = "1.0", features = ["derive"] }
 serde-big-array = "0.5.1"
 string-interner = "0.19.0"

--- a/bff/src/bigfile/manifest.rs
+++ b/bff/src/bigfile/manifest.rs
@@ -1,29 +1,30 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::bigfile::platforms::Platform;
 use crate::bigfile::versions::{Version, VersionXple};
 use crate::names::Name;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
 pub struct ManifestPoolResourceEntry {
     pub name: Name,
     pub reference_record_index: u32,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
 pub struct ManifestPoolReferenceRecord {
     pub resource_entries_starting_index: u32,
     pub resource_entries_count: u16,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
 pub struct ManifestPool {
     pub resource_entry_indices: Vec<u32>,
     pub resource_entries: Vec<ManifestPoolResourceEntry>,
     pub reference_records: Vec<ManifestPoolReferenceRecord>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
 pub struct ManifestResource {
     pub name: Name,
     // TODO: Instead of a bool this should be an enum for compression type
@@ -31,7 +32,7 @@ pub struct ManifestResource {
     pub compress: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
 pub struct ManifestBlock {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<u64>,
@@ -42,7 +43,7 @@ pub struct ManifestBlock {
     pub resources: Vec<ManifestResource>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Copy, Clone)]
 pub enum BigFileType {
     Rtc,
     Normal,
@@ -50,7 +51,7 @@ pub enum BigFileType {
     Updated1,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
 pub struct Manifest {
     pub version: Version,
     pub platform: Platform,

--- a/bff/src/bigfile/mod.rs
+++ b/bff/src/bigfile/mod.rs
@@ -16,6 +16,7 @@ pub mod versions;
 use std::collections::HashMap;
 
 use petgraph::Graph;
+use schemars::JsonSchema;
 use serde::Serialize;
 
 use crate::bigfile::manifest::Manifest;
@@ -41,7 +42,7 @@ use crate::traits::{ReferencedNames, TryIntoVersionPlatform};
 
 pub static DEFAULT_TAG: &str = "made with <3 by bff contributors (https://github.com/widberg/bff)";
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, JsonSchema, Debug)]
 pub struct BigFile {
     #[serde(flatten)]
     pub manifest: Manifest,

--- a/bff/src/bigfile/resource.rs
+++ b/bff/src/bigfile/resource.rs
@@ -1,6 +1,7 @@
 use std::io::{Read, Seek, Write};
 
 use binrw::{BinRead, BinWrite, binrw};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::platforms::Platform;
@@ -36,7 +37,7 @@ impl Resource {
 }
 
 #[binrw]
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[brw(little, magic = b"BFF0")] // Increment number when format changes
 pub struct BffResourceHeader {
     #[br(temp)]
@@ -58,7 +59,7 @@ impl BffResourceHeader {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct BffClass {
     pub header: BffResourceHeader,
     pub class: Class,

--- a/bff/src/bigfile/versions.rs
+++ b/bff/src/bigfile/versions.rs
@@ -1,6 +1,9 @@
+use std::borrow::Cow;
+
 use binrw::{BinRead, BinWrite};
 use derive_more::{Display, From};
 use scanf::sscanf;
+use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::helpers::PascalString;
@@ -150,7 +153,27 @@ impl<'de> Deserialize<'de> for Version {
     }
 }
 
-#[derive(Debug, Clone, Copy, BinRead, BinWrite, Serialize, Deserialize, From)]
+impl JsonSchema for Version {
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn schema_name() -> Cow<'static, str> {
+        "Version".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        concat!(module_path!(), "::Version").into()
+    }
+
+    fn json_schema(_schema_generator: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string"
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, BinRead, BinWrite, Serialize, Deserialize, JsonSchema, From)]
 #[serde(untagged)]
 pub enum VersionXple {
     Oneple(VersionOneple),

--- a/bff/src/class/animation/generic.rs
+++ b/bff/src/class/animation/generic.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -14,7 +15,7 @@ use crate::helpers::{
 };
 use crate::names::Name;
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct AnimationNode {
     pub unknown: u16,
     pub keyframer_rot: KeyframerRot,
@@ -24,7 +25,7 @@ pub struct AnimationNode {
     pub keyframer_message: KeyframerMessage,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct AnimationNodeModifier {
     pub bone_name: Name,
     pub bone_id: u16,
@@ -41,7 +42,7 @@ pub struct AnimationNodeModifier {
     pub message_frame_count: u16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct AnimationMaterial {
     pub keyframer_float_comp0: KeyframerFloatComp,
     pub keyframer_float_comp1: KeyframerFloatComp,
@@ -50,7 +51,7 @@ pub struct AnimationMaterial {
     pub keyframer_float_comp2: KeyframerFloatComp,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct AnimationMaterialModifier {
     pub material_link_name: Name,
     pub material_id: u16,
@@ -67,12 +68,12 @@ pub struct AnimationMaterialModifier {
     pub keyframer_float_comp2_frame_count: u16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct AnimationMesh {
     pub keyframer_float_comp: KeyframerFloatComp,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct AnimationMeshModifier {
     pub mesh_link_name: Name,
     pub mesh_id: u16,
@@ -81,12 +82,12 @@ pub struct AnimationMeshModifier {
     pub keyframer_float_comp_frame_count: u16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct AnimationMorph {
     pub keyframer_float_comp: KeyframerFloatComp,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct AnimationMorphModifier {
     pub mesh_link_name: Name,
     pub mesh_id: u16,

--- a/bff/src/class/animation/v1_291_03_06_pc.rs
+++ b/bff/src/class/animation/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::{GenericClass, ReferencedNames};
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::{
@@ -18,7 +19,9 @@ use crate::helpers::{DynArray, ResourceObjectLinkHeaderV1_06_63_02PC};
 use crate::macros::trivial_class_generic::trivial_class_generic;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, GenericClass,
+)]
 #[generic(complete)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct AnimationBodyV1_291_03_06PC {

--- a/bff/src/class/animation/v1_381_67_09_pc.rs
+++ b/bff/src/class/animation/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::{GenericClass, ReferencedNames};
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::{
@@ -18,7 +19,9 @@ use crate::helpers::{DynArray, ResourceObjectLinkHeaderV1_381_67_09PC};
 use crate::macros::trivial_class_generic::trivial_class_generic;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, GenericClass,
+)]
 #[generic(complete)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct AnimationBodyV1_381_67_09PC {

--- a/bff/src/class/binary/v1_381_67_09_pc.rs
+++ b/bff/src/class/binary/v1_381_67_09_pc.rs
@@ -1,6 +1,7 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -8,25 +9,29 @@ use crate::helpers::ResourceObjectLinkHeaderV1_381_67_09PC;
 use crate::traits::{Export, Import};
 
 #[bitsize(32)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct LookupDescription {
     horizon: u12,
     altitudes_index: u20,
 }
 
 #[bitsize(8)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct AltitudePack {
     odd: u4,
     even: u4,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct AltitudesPacked {
     altitudes: [AltitudePack; 8],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct AltitudesUnpacked {
     altitudes: [u8; 16],
 }
@@ -35,7 +40,7 @@ impl AltitudesPacked {
     const SIZE: u32 = 8;
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Internal {
     width: u32,
     height: u32,
@@ -52,7 +57,7 @@ struct Internal {
     lookup: Vec<LookupDescription>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct BinaryBodyV1_381_67_09PC {
     data_size: u32,

--- a/bff/src/class/bitmap/v1_06_63_02_pc.rs
+++ b/bff/src/class/bitmap/v1_06_63_02_pc.rs
@@ -4,6 +4,7 @@ use std::ffi::OsString;
 use bff_derive::{GenericClass, ReferencedNames};
 use binrw::helpers::until_eof;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::{BitmapBodyGeneric, BitmapGeneric, BitmapHeaderGeneric};
@@ -13,7 +14,9 @@ use crate::error::Error;
 use crate::helpers::ResourceObjectLinkHeaderV1_06_63_02PC;
 use crate::traits::{Artifact, Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, GenericClass,
+)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct BitmapBodyV1_06_63_02PC {
     width: u32,

--- a/bff/src/class/bitmap/v1_291_03_06_pc.rs
+++ b/bff/src/class/bitmap/v1_291_03_06_pc.rs
@@ -4,6 +4,7 @@ use std::ffi::OsString;
 use bff_derive::{GenericClass, ReferencedNames};
 use binrw::helpers::until_eof;
 use binrw::{BinRead, BinWrite, binread};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::{BitmapBodyGeneric, BitmapGeneric, BitmapHeaderGeneric};
@@ -14,7 +15,15 @@ use crate::helpers::ResourceObjectLinkHeaderV1_06_63_02PC;
 use crate::traits::{Artifact, Export, Import};
 
 #[derive(
-    BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass, Clone,
+    BinRead,
+    Debug,
+    Serialize,
+    BinWrite,
+    Deserialize,
+    ReferencedNames,
+    GenericClass,
+    Clone,
+    JsonSchema,
 )]
 #[generic(name(BitmapHeaderGeneric))]
 pub struct BitmapHeader {
@@ -32,7 +41,7 @@ pub struct BitmapHeader {
 }
 
 #[binread]
-#[derive(Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
+#[derive(Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass, JsonSchema)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct BitmapBodyV1_291_03_06PC {
     header: BitmapHeader,

--- a/bff/src/class/bitmap/v1_381_67_09_pc.rs
+++ b/bff/src/class/bitmap/v1_381_67_09_pc.rs
@@ -6,6 +6,7 @@ use bff_derive::{GenericClass, ReferencedNames};
 use binrw::helpers::until_eof;
 use binrw::{BinRead, BinWrite};
 use ddsfile::{D3DFormat, Dds, NewD3dParams};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::BitmapGeneric;
@@ -16,7 +17,9 @@ use crate::macros::trivial_class_generic::trivial_class_generic;
 use crate::names::Name;
 use crate::traits::{Artifact, Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, Copy, Clone)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, Copy, Clone,
+)]
 #[brw(repr = u16)]
 enum BitmapClass {
     Single = 0,
@@ -24,7 +27,16 @@ enum BitmapClass {
 }
 
 #[derive(
-    BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, Copy, Clone, Default,
+    BinRead,
+    Debug,
+    Serialize,
+    BinWrite,
+    Deserialize,
+    ReferencedNames,
+    Copy,
+    Clone,
+    Default,
+    JsonSchema,
 )]
 #[brw(repr = u8)]
 enum BmFormat {
@@ -35,14 +47,18 @@ enum BmFormat {
     BmDxt5 = 16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, Copy, Clone)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, Copy, Clone,
+)]
 #[brw(repr = u8)]
 enum BitmapClass2 {
     Cubemap2 = 0,
     Single2 = 3,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, Copy, Clone)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, Copy, Clone,
+)]
 #[brw(repr = u8)]
 enum BmTransp {
     NoTransp = 0,
@@ -51,7 +67,9 @@ enum BmTransp {
     Cubemap = 255,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, GenericClass,
+)]
 #[generic(name(BitmapHeaderGeneric))]
 pub struct LinkHeader {
     #[referenced_names(skip)]
@@ -82,7 +100,9 @@ pub struct LinkHeader {
     transparency: BmTransp,
 }
 
-#[derive(Debug, BinRead, BinWrite, Serialize, Deserialize, ReferencedNames, GenericClass)]
+#[derive(
+    Debug, BinRead, BinWrite, Serialize, Deserialize, ReferencedNames, GenericClass, JsonSchema,
+)]
 #[br(import(_link_header: &LinkHeader))]
 pub struct BitmapBodyV1_381_67_09PC {
     #[br(parse_with = until_eof)]

--- a/bff/src/class/camera/v1_381_67_09_pc.rs
+++ b/bff/src/class/camera/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::ObjectLinkHeaderV1_381_67_09PC;
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct CameraBodyV1_381_67_09PC {
     angle_of_view: f32,

--- a/bff/src/class/camera_zone/v1_06_63_02_pc.rs
+++ b/bff/src/class/camera_zone/v1_06_63_02_pc.rs
@@ -1,18 +1,19 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{DynArray, ObjectLinkHeaderV1_06_63_02PC, RGBA, Vec2f, Vec3f, Vec4f};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct RangeSizeOffset {
     size: u16,
     offset: u16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SplineZoneSead {
     p_min: Vec2f,
     p_max: Vec2f,
@@ -25,13 +26,13 @@ struct SplineZoneSead {
     zone_indices: DynArray<u16>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Spline {
     pt_0_id: u16,
     pt_1_id: u16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SplineZone {
     y: f32,
     spline_ids_ref: RangeSizeOffset,
@@ -40,7 +41,7 @@ struct SplineZone {
     unknown1: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SplineZoneZ {
     unknown: Vec4f,
     points: DynArray<Vec3f>,
@@ -51,7 +52,7 @@ struct SplineZoneZ {
     spline_zone_sead: SplineZoneSead,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Trigger {
     rot: f32,
     fov: f32,
@@ -69,12 +70,12 @@ struct Trigger {
     unknown: Vec3f,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ZoneTriggers {
     trigger_ids_ref: RangeSizeOffset,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct CameraZoneBodyV1_06_63_02PC {
     spline_zone: SplineZoneZ,

--- a/bff/src/class/collision_vol/v1_291_03_06_pc.rs
+++ b/bff/src/class/collision_vol/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,13 +8,13 @@ use crate::helpers::{DynArray, Mat4f, ObjectLinkHeaderV1_06_63_02PC};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct CollisionVolInfo {
     local_transform: Mat4f,
     inv_local_transform: Mat4f,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct CollisionVolBodyV1_291_03_06PC {
     collision_vol_infos: DynArray<CollisionVolInfo>,

--- a/bff/src/class/collision_vol/v1_381_67_09_pc.rs
+++ b/bff/src/class/collision_vol/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,13 +8,13 @@ use crate::helpers::{DynArray, Mat4f, ObjectLinkHeaderV1_381_67_09PC};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct CollisionVolInfo {
     local_transform: Mat4f,
     local_transform_inverse: Mat4f,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct CollisionVolBodyV1_381_67_09PC {
     collision_vol_info: DynArray<CollisionVolInfo>,

--- a/bff/src/class/fonts/v1_381_67_09_pc.rs
+++ b/bff/src/class/fonts/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinResult, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -37,7 +38,16 @@ fn parse_character() -> BinResult<char> {
 }
 
 #[derive(
-    BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, PartialEq, Eq, Hash,
+    BinRead,
+    Debug,
+    Serialize,
+    BinWrite,
+    Deserialize,
+    ReferencedNames,
+    PartialEq,
+    Eq,
+    Hash,
+    JsonSchema,
 )]
 struct CharacterID(
     #[br(parse_with = parse_character)]
@@ -45,7 +55,7 @@ struct CharacterID(
     char,
 );
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Character {
     material_index: u32,
     descent: f32,
@@ -53,7 +63,7 @@ struct Character {
     bottom_right_corner: Vec2f,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct FontsBodyV1_381_67_09PC {
     characters: BffMap<CharacterID, Character>,
@@ -67,7 +77,7 @@ impl Export for FontsV1_381_67_09PC {}
 impl Import for FontsV1_381_67_09PC {}
 
 // TODO: Shouldn't need to duplicate this just because the link header type is different
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct FontsBodyV1_06_63_02PC {
     characters: BffMap<CharacterID, Character>,

--- a/bff/src/class/game_obj/v1_291_03_06_pc.rs
+++ b/bff/src/class/game_obj/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::{DynArray, ResourceObjectLinkHeaderV1_06_63_02PC};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, JsonSchema)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct GameObjBodyV1_291_03_06PC {
     node_names: DynArray<Name>,

--- a/bff/src/class/game_obj/v1_381_67_09_pc.rs
+++ b/bff/src/class/game_obj/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,14 +8,14 @@ use crate::helpers::{DynArray, PascalStringNull, ResourceObjectLinkHeaderV1_381_
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Prefab {
     string: PascalStringNull,
     in_world: u32,
     names: DynArray<Name>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct GameObjBodyV1_381_67_09PC {
     prefabs: DynArray<Prefab>,

--- a/bff/src/class/gen_world/v1_381_67_09_pc.rs
+++ b/bff/src/class/gen_world/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -16,13 +17,13 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Category {
     one: u32,
     node_name_arrays: DynArray<Name>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct CAFlatSurface {
     zero0: u32,
     mat: Mat4f,
@@ -47,7 +48,7 @@ struct CAFlatSurface {
     unknown2: u8,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused10 {
     unused0: u32,
     unused1s: [u32; 8],
@@ -56,19 +57,19 @@ struct Unused10 {
     unused4: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct RegionEdge {
     region_vertices_index_a: u32,
     region_vertices_index_b: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Region {
     unknown: u8,
     region_edges_indices: DynArray<u32>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct GenWorldBodyV1_381_67_09PC {
     node_name: Name,

--- a/bff/src/class/gw_road/v1_381_67_09_pc.rs
+++ b/bff/src/class/gw_road/v1_381_67_09_pc.rs
@@ -4,6 +4,7 @@ use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinResult, BinWrite, BinWriterExt, Endian};
 use derive_more::{Deref, DerefMut};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -12,7 +13,7 @@ use crate::names::Name;
 use crate::traits::{Export, Import};
 
 #[bitsize(7)]
-#[derive(TryFromBits, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(TryFromBits, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 enum SubType {
     ShortCutForest = 0,
     ShortCutField = 1,
@@ -36,13 +37,15 @@ enum SubType {
 }
 
 #[bitsize(8)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct RoadType {
     sub_type: SubType,
     short_cut: bool,
 }
 
-#[derive(Debug, Serialize, Deref, DerefMut, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deref, DerefMut, Deserialize, ReferencedNames, JsonSchema)]
 #[serde(transparent)]
 struct EncodedPoint(Vec2f);
 
@@ -89,13 +92,13 @@ impl BinWrite for EncodedPoint {
     }
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Road {
     r#type: RoadType,
     points: DynArray<EncodedPoint, u16>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused5 {
     unused0: u32,
     unused1: u32,
@@ -109,7 +112,7 @@ struct Unused5 {
     unused8s: Vec<u32>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct GwRoadBodyV1_381_67_09PC {
     road_count: u32,

--- a/bff/src/class/light/v1_291_03_06_pc.rs
+++ b/bff/src/class/light/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::{GenericClass, ReferencedNames};
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::LightGeneric;
@@ -8,7 +9,9 @@ use crate::helpers::{ObjectLinkHeaderV1_06_63_02PC, Quat, RGBA, Vec3f};
 use crate::macros::trivial_class_generic::trivial_class_generic;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, GenericClass,
+)]
 #[generic(complete)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct LightBodyV1_291_03_06PC {

--- a/bff/src/class/light/v1_381_67_09_pc.rs
+++ b/bff/src/class/light/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::{GenericClass, ReferencedNames};
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::LightGeneric;
@@ -8,7 +9,9 @@ use crate::helpers::{ObjectLinkHeaderV1_381_67_09PC, Quat, RGBA, Vec3f};
 use crate::macros::trivial_class_generic::trivial_class_generic;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, GenericClass,
+)]
 #[generic(complete)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct LightBodyV1_381_67_09PC {

--- a/bff/src/class/light_data/v1_06_63_02_pc.rs
+++ b/bff/src/class/light_data/v1_06_63_02_pc.rs
@@ -1,18 +1,19 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{RGB, RGBA, ResourceObjectLinkHeaderV1_06_63_02PC, Vec3f};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ObjectDatas {
     unknown: f32,
     color: RGBA,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct LightDataBodyV1_06_63_02PC {
     object_datas: ObjectDatas,

--- a/bff/src/class/light_data/v1_291_03_06_pc.rs
+++ b/bff/src/class/light_data/v1_291_03_06_pc.rs
@@ -1,17 +1,18 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{RGB, RGBA, ResourceObjectLinkHeaderV1_06_63_02PC};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ObjectDatas {
     color: RGBA,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct LightDataBodyV1_291_03_06PC {
     object_datas: ObjectDatas,

--- a/bff/src/class/light_data/v1_381_67_09_pc.rs
+++ b/bff/src/class/light_data/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -11,7 +12,7 @@ use crate::helpers::{
 };
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct LightDataBodyV1_381_67_09PC {
     resource_datas_flags: ObjectDatasFlagsV1_381_67_09PC,

--- a/bff/src/class/lod/v1_06_63_02_pc.rs
+++ b/bff/src/class/lod/v1_06_63_02_pc.rs
@@ -1,32 +1,32 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 
 use crate::class::trivial_class::TrivialClass;
-use crate::helpers::{DynArray, DynBox, DynSphere, ObjectLinkHeaderV1_06_63_02PC, Vec3f};
+use crate::helpers::{Cylindre, DynArray, DynBox, DynSphere, ObjectLinkHeaderV1_06_63_02PC, Vec3f};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ClassRes {
     id: u32,
     crc32: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SphereColNode {
     data: [u8; 28],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct CylindreCol {
-    #[serde(with = "BigArray")]
-    data: [u8; 40],
+    cylindre: Cylindre,
+    flag: u32,
     name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct LodBodyV1_06_63_02PC {
     b_sphere_col_node: Name,

--- a/bff/src/class/lod/v1_291_03_06_pc.rs
+++ b/bff/src/class/lod/v1_291_03_06_pc.rs
@@ -1,11 +1,12 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{
     BffOption,
+    Cylindre,
     DynArray,
     DynBox,
     DynSphere,
@@ -15,25 +16,25 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct CylindreCol {
-    #[serde(with = "BigArray")]
-    data: [u8; 40],
+    cylindre: Cylindre,
+    flag: u32,
     name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SphereColNode {
     data: [u8; 28],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ClassRes {
     id: u32,
     crc32: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct LodBodyV1_291_03_06PC {
     b_sphere_col_node: Name,

--- a/bff/src/class/lod/v1_381_67_09_pc.rs
+++ b/bff/src/class/lod/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -14,14 +15,14 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct FadeDistances {
     x: f32,
     y: f32,
     fade_close: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct LodBodyV1_381_67_09PC {
     collision_spheres: DynArray<DynSphere>,

--- a/bff/src/class/lod_data/v1_06_63_02_pc.rs
+++ b/bff/src/class/lod_data/v1_06_63_02_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,13 +8,13 @@ use crate::helpers::{BffOption, DynArray, RGBA, ResourceObjectLinkHeaderV1_06_63
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ObjectDatas {
     flags: u32,
     color: RGBA,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct UnkStruct {
     unk1_name: Name,
     unk2_name: Name,
@@ -21,7 +22,7 @@ struct UnkStruct {
     unks: DynArray<u32>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ActorData {
     placeholder1: [u32; 7],
     zero1: u32,
@@ -36,7 +37,7 @@ struct ActorData {
     unk_structs: DynArray<UnkStruct>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct LodDataBodyV1_06_63_02PC {
     object_datas: ObjectDatas,

--- a/bff/src/class/lod_data/v1_291_03_06_pc.rs
+++ b/bff/src/class/lod_data/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::{BffOption, DynArray, ResourceObjectLinkHeaderV1_06_63_02PC,
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Extended {
     padding: [u8; 24],
     flags: u32,
@@ -20,7 +21,7 @@ struct Extended {
     zero3s: [u32; 4],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct LodDataBodyV1_291_03_06PC {
     flags: u32,

--- a/bff/src/class/lod_data/v1_381_67_09_pc.rs
+++ b/bff/src/class/lod_data/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -13,7 +14,7 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Extended {
     pad: [u8; 24],
     flags1: u32,
@@ -33,7 +34,7 @@ struct Extended {
     zero11: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct LodDataBodyV1_381_67_09PC {
     flags: ObjectDatasFlagsV1_381_67_09PC,

--- a/bff/src/class/material/v1_06_63_02_pc.rs
+++ b/bff/src/class/material/v1_06_63_02_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -15,7 +16,7 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct MaterialBodyV1_06_63_02PC {
     diffuse: RGBA,

--- a/bff/src/class/material/v1_291_03_06_pc.rs
+++ b/bff/src/class/material/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::{Mat3f, RGB, RGBA, ResourceObjectLinkHeaderV1_06_63_02PC};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct MaterialBodyV1_291_03_06PC {
     pub diffuse: RGBA,

--- a/bff/src/class/material/v1_381_67_09_pc.rs
+++ b/bff/src/class/material/v1_381_67_09_pc.rs
@@ -1,6 +1,7 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -9,7 +10,9 @@ use crate::names::Name;
 use crate::traits::{Export, Import};
 
 #[bitsize(32)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct MaterialEnabledBitmaps {
     diffuse: u1,
     unused0: u1,
@@ -24,14 +27,16 @@ struct MaterialEnabledBitmaps {
 }
 
 #[bitsize(32)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct MaterialRdrFlags {
     padding0: u5,
     transparency: u1,
     padding1: u26,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct MaterialBodyV1_381_67_09PC {
     diffuse: RGBA,

--- a/bff/src/class/material_anim/v1_381_67_09_pc.rs
+++ b/bff/src/class/material_anim/v1_381_67_09_pc.rs
@@ -1,6 +1,7 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -17,7 +18,9 @@ use crate::names::Name;
 use crate::traits::{Export, Import};
 
 #[bitsize(8)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct MaterialAnimFlags {
     fl_mat_play: u1,
     fl_mat_played: u1,
@@ -29,7 +32,7 @@ struct MaterialAnimFlags {
     flag_7: u1,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct MaterialAnimBodyV1_381_67_09PC {
     bitmap_name_keyframer: KeyframerHdl,

--- a/bff/src/class/material_obj/v1_381_67_09_pc.rs
+++ b/bff/src/class/material_obj/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::{BffMap, DynArray, ResourceObjectLinkHeaderV1_381_67_09PC};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct MaterialObjBodyV1_381_67_09PC {
     entries: BffMap<Name, DynArray<Name>>,

--- a/bff/src/class/mesh/generic.rs
+++ b/bff/src/class/mesh/generic.rs
@@ -1,6 +1,7 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite, args};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::helpers::{DynArray, RangeBeginSize, Vec2f, Vec3f};
@@ -10,7 +11,7 @@ type VertexVectorComponent = u8;
 type VertexVector3u8 = [VertexVectorComponent; 3];
 type VertexBlendIndex = f32;
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(is_leaf: bool))]
 pub enum CollisionFacesRange {
     #[br(pre_assert(is_leaf))]
@@ -19,8 +20,8 @@ pub enum CollisionFacesRange {
     Pointer(u32),
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
-pub struct CollisionAABB {
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
+pub struct AABBNode {
     min: Vec3f,
     #[br(map = |x: (u16, u16)| (x != (0, 0)).then(|| (x.0 - 1, x.1 - 1)))]
     #[bw(map = |x: &Option<(u16, u16)>| x.map(|x| (x.0 + 1, x.1 + 1)).unwrap_or((0, 0)))]
@@ -31,14 +32,14 @@ pub struct CollisionAABB {
     collision_faces_range: CollisionFacesRange,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct Strip {
     strip_vertices_indices: DynArray<u16>,
     material_name: Name,
     tri_order: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct LayoutPosition {
     pub position: Vec3f,
 }
@@ -47,7 +48,7 @@ impl LayoutPosition {
     pub const SIZE: usize = 12;
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct LayoutPositionUV {
     pub position: Vec3f,
     pub unknown: f32,
@@ -58,7 +59,7 @@ impl LayoutPositionUV {
     pub const SIZE: usize = 24;
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct LayoutNoBlend {
     pub position: Vec3f,
     pub tangent: VertexVector3u8,
@@ -73,7 +74,7 @@ impl LayoutNoBlend {
     pub const SIZE: usize = 36;
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct Layout1Blend {
     pub position: Vec3f,
     pub tangent: VertexVector3u8,
@@ -90,7 +91,7 @@ impl Layout1Blend {
     pub const SIZE: usize = 48;
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct Layout4Blend {
     pub position: Vec3f,
     pub tangent: VertexVector3u8,
@@ -106,7 +107,7 @@ impl Layout4Blend {
     pub const SIZE: usize = 60;
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(count: usize, layout: usize))]
 pub enum Vertices {
     #[br(pre_assert(layout == LayoutPosition::SIZE))]
@@ -164,7 +165,9 @@ impl Vertices {
 }
 
 #[bitsize(32)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 pub struct VertexGroupFlags {
     padding: u2,
     visible: u1,

--- a/bff/src/class/mesh/v1_291_03_06_pc.rs
+++ b/bff/src/class/mesh/v1_291_03_06_pc.rs
@@ -1,11 +1,12 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite, binrw};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 
-use super::generic::{CollisionAABB, Strip, VertexGroupFlags, Vertices};
+use super::generic::{AABBNode, Strip, VertexGroupFlags, Vertices};
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{
+    Cylindre,
     DynArray,
     DynBox,
     DynSphere,
@@ -18,73 +19,69 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct PointsRelated0 {
     data: [u8; 12],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct PointsRelated1 {
     data: [u8; 16],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct PointsRelated2 {
     data: [u8; 4],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown1 {
     unknown1: [u8; 8],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown2 {
     unknown2: [u8; 12],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown5 {
     unknown8_count: u32,
     #[br(count = unknown8_count * 8)]
     unknown8: Vec<u8>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown6 {
     unknowns: [u32; 8],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown7 {
-    // Big array helper for serde.
-    // The purpose of this crate is to make (de-)serializing arrays of sizes > 32 easy.
-    // This solution is needed until serde adopts const generics support.
-    // https://github.com/serde-rs/serde/issues/1937
-    #[serde(with = "BigArray")]
-    data: [u8; 44],
+    data1: [u8; 32],
+    data2: [u8; 12],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown8 {
     data: [u8; 16],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Points {
     points_related0: DynArray<PointsRelated0>,
     points_related1: DynArray<PointsRelated1>,
     points_related2: DynArray<PointsRelated2>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct CylindreCol {
-    #[serde(with = "BigArray")]
-    data: [u8; 40],
+    cylindre: Cylindre,
+    flag: u32,
     name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct AABBColTri {
     first_vertex_id: i16,
     second_vertex_id: i16,
@@ -93,7 +90,7 @@ struct AABBColTri {
 }
 
 #[binrw]
-#[derive(Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 pub struct VertexBuffer {
     #[br(temp)]
     #[bw(calc = vertices.len() as u32)]
@@ -107,7 +104,7 @@ pub struct VertexBuffer {
 }
 
 #[binrw]
-#[derive(Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 pub struct IndexBuffer {
     #[br(temp)]
     #[bw(calc = tris.len() as u32 * 3)]
@@ -117,7 +114,7 @@ pub struct IndexBuffer {
     pub tris: Vec<Vec3i16>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct VertexGroup {
     zeroes: Vec3<u32>,
     flags: VertexGroupFlags,
@@ -132,29 +129,29 @@ pub struct VertexGroup {
     unused: u16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct MorpherRelated {
     data: [u8; 16],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct MorphTargetDescRelated {
     data: [u8; 16],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct MorpherTargetDesc {
     name: Name,
     morph_target_desc_relateds: DynArray<MorphTargetDescRelated>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Morpher {
     morpher_relateds: DynArray<MorpherRelated>,
     morpher_descs: DynArray<MorpherTargetDesc>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct MeshBuffers {
     pub vertex_buffers: DynArray<VertexBuffer>,
     pub index_buffers: DynArray<IndexBuffer>,
@@ -163,7 +160,7 @@ pub struct MeshBuffers {
     morpher: Morpher,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct MeshBodyV1_291_03_06PC {
     points: Points,
@@ -183,7 +180,7 @@ pub struct MeshBodyV1_291_03_06PC {
     box_cols: DynArray<DynBox>,
     cylindre_cols: DynArray<CylindreCol>,
     collision_aabb_tris: DynArray<AABBColTri>,
-    collision_aabbs: DynArray<CollisionAABB>,
+    collision_aabbs: DynArray<AABBNode>,
     vertices: DynArray<Vec3i16>,
     unknown6s: DynArray<Unknown6>,
     pub mesh_buffers: MeshBuffers,

--- a/bff/src/class/mesh/v1_381_67_09_pc.rs
+++ b/bff/src/class/mesh/v1_381_67_09_pc.rs
@@ -1,9 +1,10 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite, binrw};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::generic::{CollisionAABB, Strip, VertexGroupFlags, Vertices};
+use super::generic::{AABBNode, Strip, VertexGroupFlags, Vertices};
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{
     BffMap,
@@ -25,14 +26,14 @@ use crate::traits::{Export, Import};
 type DisplacementVectorComponent = NumeratorFloat<i16, 1024>;
 type ShortVecWeird = [NumeratorFloat<i16, 1024>; 3];
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct FadeDistances {
     x: f32,
     y: f32,
     fade_close: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct LinkHeader {
     resource_link_header: ObjectLinkHeaderV1_381_67_09PC,
     names: DynArray<Name>,
@@ -41,7 +42,7 @@ pub struct LinkHeader {
     dyn_boxes: DynArray<DynBox>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused0 {
     unknown0: u32,
     unknown1: u32,
@@ -49,31 +50,33 @@ struct Unused0 {
     unknown3: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused00 {
     unused0: u32,
     unused1: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused4 {
     unused0s: DynArray<Unused00>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct CollisionFace {
     short_vec_weirds_indices: [u16; 3],
     surface_type: u16,
 }
 
 // same as Unknown6 in wall-e
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused8 {
     unuseds: [u32; 8],
 }
 
 #[bitsize(32)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct D3DFlags {
     d3d_pool_default: u1,
     d3d_pool_managed: u1,
@@ -88,7 +91,7 @@ struct D3DFlags {
 }
 
 #[binrw]
-#[derive(Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct VertexBufferExt {
     #[br(temp)]
     #[bw(calc = vertices.len() as u32)]
@@ -102,7 +105,7 @@ struct VertexBufferExt {
 }
 
 #[binrw]
-#[derive(Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct IndexBufferExt {
     #[br(temp)]
     #[bw(calc = tris.len() as u32 * 3)]
@@ -112,13 +115,13 @@ struct IndexBufferExt {
     tris: Vec<Vec3i16>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Quad {
     vertices: [Vec3f; 4],
     normal: Vec3f,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused1 {
     unused0: u32,
     unused1: u32,
@@ -129,7 +132,7 @@ struct Unused1 {
     unused6: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct VertexGroup {
     vertex_buffer_index: u32,
     index_buffer_index: u32,
@@ -146,7 +149,7 @@ struct VertexGroup {
     unused1s: DynArray<Unused1>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct AABBMorphTrigger {
     min: Vec3f,
     aabb_morph_triggers_range: RangeFirstLast,
@@ -154,13 +157,13 @@ struct AABBMorphTrigger {
     map_index_range: RangeBeginSize,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct DisplacementVector {
     displacement: [DisplacementVectorComponent; 3],
     displacement_vectors_self_index: u16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct MorphTargetDesc {
     name: PascalString,
     base_vertex_buffer_id: u32,
@@ -169,7 +172,7 @@ struct MorphTargetDesc {
     displacement_vectors: DynArray<DisplacementVector>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Morpher {
     aabb_morph_triggers: DynArray<AABBMorphTrigger>,
     map: BffMap<u16, u16>,
@@ -177,7 +180,7 @@ struct Morpher {
     morphs: DynArray<MorphTargetDesc>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct MeshBuffers {
     vertex_buffers: DynArray<VertexBufferExt>,
     index_buffers: DynArray<IndexBufferExt>,
@@ -186,7 +189,7 @@ struct MeshBuffers {
     morpher: Morpher,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &LinkHeader))]
 pub struct MeshBodyV1_381_67_09PC {
     strip_vertices: DynArray<Vec3f>,
@@ -196,7 +199,7 @@ pub struct MeshBodyV1_381_67_09PC {
     strips: DynArray<Strip>,
     unused4s: DynArray<Unused4>,
     material_names: DynArray<Name>,
-    collision_aabbs: DynArray<CollisionAABB>,
+    collision_aabbs: DynArray<AABBNode>,
     collision_faces: DynArray<CollisionFace>,
     unused8s: DynArray<Unused8>,
     mesh_buffers: MeshBuffers,

--- a/bff/src/class/mesh_data/v1_06_63_02_pc.rs
+++ b/bff/src/class/mesh_data/v1_06_63_02_pc.rs
@@ -1,38 +1,39 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{DynArray, RGBA, ResourceObjectLinkHeaderV1_06_63_02PC};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ObjectDatas {
     unknown: f32,
     color: RGBA,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct UnkStruct1 {
     data: [u8; 16],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct UnkStruct2 {
     data: [u8; 16],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct UnkStruct3 {
     data: [u8; 32],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct UnkStruct4 {
     data: [u8; 16],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct MeshVolume {
     unk_struct1s: DynArray<UnkStruct1>,
     unk_struct2s: DynArray<UnkStruct2>,
@@ -40,7 +41,7 @@ struct MeshVolume {
     unk_struct4s: DynArray<UnkStruct4>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct MeshDataBodyV1_06_63_02PC {
     object_datas: ObjectDatas,

--- a/bff/src/class/mesh_data/v1_291_03_06_pc.rs
+++ b/bff/src/class/mesh_data/v1_291_03_06_pc.rs
@@ -1,18 +1,19 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{RGBA, ResourceObjectLinkHeaderV1_06_63_02PC};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ObjectDatas {
     unknown_float: f32,
     color: RGBA,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct MeshDataBodyV1_291_03_06PC {
     object_datas: ObjectDatas,

--- a/bff/src/class/mesh_data/v1_381_67_09_pc.rs
+++ b/bff/src/class/mesh_data/v1_381_67_09_pc.rs
@@ -1,12 +1,13 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{ObjectDatasFlagsV1_381_67_09PC, ResourceObjectLinkHeaderV1_381_67_09PC};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct MeshDataBodyV1_381_67_09PC {
     flags: ObjectDatasFlagsV1_381_67_09PC,

--- a/bff/src/class/node/v1_06_63_02_pc.rs
+++ b/bff/src/class/node/v1_06_63_02_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -15,7 +16,7 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct NodeBodyV1_06_63_02PC {
     parent_name: Name,

--- a/bff/src/class/node/v1_291_03_06_pc.rs
+++ b/bff/src/class/node/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -15,7 +16,7 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct NodeBodyV1_291_03_06PC {
     parent_name: Name,

--- a/bff/src/class/node/v1_381_67_09_pc.rs
+++ b/bff/src/class/node/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -15,7 +16,7 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct NodeBodyV1_381_67_09PC {
     parent_name: Name,

--- a/bff/src/class/omni/mod.rs
+++ b/bff/src/class/omni/mod.rs
@@ -1,9 +1,12 @@
 use crate::macros::bff_class::bff_class;
 
+mod v1_06_63_02_pc;
 mod v1_381_67_09_pc;
 
+use v1_06_63_02_pc::OmniV1_06_63_02PC;
 use v1_381_67_09_pc::OmniV1_381_67_09PC;
 
 bff_class!(Omni {
+    (Asobo(1, 6, 63, 2), PC) => OmniV1_06_63_02PC,
     (Asobo(1, 381, 67, 9), PC) => OmniV1_381_67_09PC,
 });

--- a/bff/src/class/omni/v1_06_63_02_pc.rs
+++ b/bff/src/class/omni/v1_06_63_02_pc.rs
@@ -1,0 +1,30 @@
+use bff_derive::ReferencedNames;
+use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::class::trivial_class::TrivialClass;
+use crate::helpers::{Mat4f, ObjectLinkHeaderV1_06_63_02PC, Vec3f};
+use crate::names::Name;
+use crate::traits::{Export, Import};
+
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
+#[br(import(_link_header: &ObjectLinkHeaderV1_06_63_02PC))]
+pub struct OmniBodyV1_06_63_02PC {
+    texture_projection_matrix: Mat4f,
+    color: Vec3f,
+    intensity: f32,
+    scaled_color: Vec3f,
+    unused: f32,
+    spot_angle_half_rad: f32,
+    spot_angle_scale: f32,
+    spot_angle_bias: f32,
+    start: f32,
+    end: f32,
+    material_anim_name: Name,
+}
+
+pub type OmniV1_06_63_02PC = TrivialClass<ObjectLinkHeaderV1_06_63_02PC, OmniBodyV1_06_63_02PC>;
+
+impl Export for OmniV1_06_63_02PC {}
+impl Import for OmniV1_06_63_02PC {}

--- a/bff/src/class/omni/v1_381_67_09_pc.rs
+++ b/bff/src/class/omni/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::{Mat4f, ObjectLinkHeaderV1_381_67_09PC};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct OmniBodyV1_381_67_09PC {
     scale_matrix: Mat4f,

--- a/bff/src/class/particles/v1_381_67_09_pc.rs
+++ b/bff/src/class/particles/v1_381_67_09_pc.rs
@@ -1,6 +1,7 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -18,7 +19,9 @@ use crate::names::Name;
 use crate::traits::{Export, Import};
 
 #[bitsize(32)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct ParticlesEmitterFlags {
     fl_particles_loop: u1,
     fl_particles_lock_h: u1,
@@ -39,7 +42,7 @@ struct ParticlesEmitterFlags {
     padding: u16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ParticlesEmitter {
     max_quantity: u16,
     p_cloud_type: u16,
@@ -67,7 +70,7 @@ struct ParticlesEmitter {
     material_anim_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct ParticlesBodyV1_381_67_09PC {
     particles_emitters: DynArray<ParticlesEmitter>,

--- a/bff/src/class/particles_data/v1_381_67_09_pc.rs
+++ b/bff/src/class/particles_data/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -11,14 +12,14 @@ use crate::helpers::{
 };
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct FadeDistances {
     x: f32,
     y: f32,
     fade_close: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct ParticlesDataBodyV1_381_67_09PC {
     flags: ObjectDatasFlagsV1_381_67_09PC,

--- a/bff/src/class/rot_shape/v1_06_63_02_pc.rs
+++ b/bff/src/class/rot_shape/v1_06_63_02_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,39 +8,39 @@ use crate::helpers::{DynArray, ResourceObjectLinkHeaderV1_06_63_02PC, Vec2f, Vec
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct PointsRelated0 {
     data: [u8; 12],
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct PointsRelated1 {
     data: [u8; 16],
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct MorpherRelated {
     data: [u8; 16],
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct MorphTargetDescRelated {
     data: [u8; 16],
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct MorphTargetDesc {
     name: u32,
     morph_target_desc_relateds: DynArray<MorphTargetDescRelated>,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct Morpher {
     morpher_relateds: DynArray<MorpherRelated>,
     morph_target_descs: DynArray<MorphTargetDesc>,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 pub struct LinkInfo {
     resource_link_header: ResourceObjectLinkHeaderV1_06_63_02PC,
     vertices: DynArray<Vec3f>,
@@ -47,7 +48,7 @@ pub struct LinkInfo {
     morpher: Morpher,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 #[br(import(_link_header: &LinkInfo))]
 pub struct RotShapeBodyV1_06_63_02PC {
     material_indices: DynArray<u32>,

--- a/bff/src/class/rot_shape/v1_291_03_06_pc.rs
+++ b/bff/src/class/rot_shape/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,24 +8,24 @@ use crate::helpers::{DynArray, ObjectLinkHeaderV1_06_63_02PC, Vec2f, Vec3f};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct PointsRelated0 {
     data: [u8; 16],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct PointsRelated1 {
     data: [u8; 4],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Points {
     vertices: DynArray<Vec3f>,
     points_related0s: DynArray<PointsRelated0>,
     points_related1s: DynArray<PointsRelated1>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct RotShapeBodyV1_291_03_06PC {
     points: Points,

--- a/bff/src/class/rot_shape/v1_381_67_09_pc.rs
+++ b/bff/src/class/rot_shape/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,14 +8,14 @@ use crate::helpers::{DynArray, ObjectLinkHeaderV1_381_67_09PC, Vec2f, Vec3f};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[brw(repr = u16)]
 enum BillboardMode {
     YBillboard = 0,
     CompleteBillboard = 1,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct RotShapeBodyV1_381_67_09PC {
     origins: DynArray<Vec3f>,

--- a/bff/src/class/rot_shape_data/v1_381_67_09_pc.rs
+++ b/bff/src/class/rot_shape_data/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -10,7 +11,7 @@ use crate::helpers::{
 };
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct RotShapeDataBodyV1_381_67_09PC {
     flags: ObjectDatasFlagsV1_381_67_09PC,

--- a/bff/src/class/rtc/v1_381_67_09_pc.rs
+++ b/bff/src/class/rtc/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -16,7 +17,7 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct RtcAnimationNode {
     unknown_node_name: Name,
     rtc_animation_node_flag: u16,
@@ -26,7 +27,7 @@ struct RtcAnimationNode {
     unknown3: KeyframerMessage,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct AnimationCamera {
     unknown_node_name: Name,
     animation_camera_flag: u16,
@@ -36,7 +37,7 @@ struct AnimationCamera {
     unknown3: KeyframerFloatComp,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct AnimationOmni {
     unknown_node_name_name: Name,
     animation_omni_flag: u16,
@@ -45,7 +46,7 @@ struct AnimationOmni {
     unknown2: KeyframerFloatComp,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown8 {
     unknown_name_name0: Name,
     unknown_name_name1: Name,
@@ -56,7 +57,7 @@ struct Unknown8 {
     unknown_name1: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown9 {
     unknown0: u32,
     unknown_name_name0: Name,
@@ -66,7 +67,7 @@ struct Unknown9 {
     unknown_name1: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct RtcBodyV1_381_67_09PC {
     duration: f32,

--- a/bff/src/class/skel/v1_06_63_02_pc.rs
+++ b/bff/src/class/skel/v1_06_63_02_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -16,13 +17,13 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ObjectDatas {
     flag: u32,
     b_sphere_local: Sphere,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct BoneNode {
     user_define_name: Name,
     local_rotation: Quat,
@@ -52,24 +53,24 @@ struct BoneNode {
     bone_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct BoneNodeGroup {
     bone_node_names: DynArray<Name>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SphereColBone {
     sphere_col: DynSphere,
     bone_node_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct BoxColBone {
     box_col: DynBox,
     bone_node_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct SkelBodyV1_06_63_02PC {
     object_datas: ObjectDatas,

--- a/bff/src/class/skel/v1_291_03_06_pc.rs
+++ b/bff/src/class/skel/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -16,13 +17,13 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ObjectDatas {
     flag: u32,
     b_sphere_local: Sphere,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct BoneNode {
     user_define_name: Name,
     local_rotation: Quat,
@@ -52,24 +53,24 @@ struct BoneNode {
     bone_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct BoneNodeGroup {
     bone_node_names: DynArray<Name>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SphereColBone {
     sphere_col: DynSphere,
     bone_node_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct BoxColBone {
     box_col: DynBox,
     bone_node_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct SkelBodyV1_291_03_06PC {
     object_datas: ObjectDatas,

--- a/bff/src/class/skel/v1_381_67_09_pc.rs
+++ b/bff/src/class/skel/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -16,7 +17,7 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Bone {
     user_define_name: Name,
     transform_rotation_inverse0: Quat,
@@ -46,19 +47,19 @@ struct Bone {
     bone_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SphereColBone {
     sphere: Sphere,
     names: [Name; 3],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct BoxColBone {
     mat: Mat4f,
     names: [Name; 3],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct SkelBodyV1_381_67_09PC {
     flags: ObjectDatasFlagsV1_381_67_09PC,

--- a/bff/src/class/skin/v1_291_03_06_pc.rs
+++ b/bff/src/class/skin/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,43 +8,43 @@ use crate::helpers::{BffMap, DynArray, ObjectLinkHeaderV1_06_63_02PC};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown1 {
     unknown1: [u8; 8],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct BlendRelated {
     index: u32,
     blend: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ResourceBlend {
     unknown: u16,
     blend_related1s: DynArray<BlendRelated>,
     blend_related2s: DynArray<BlendRelated>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Bone {
     bone_name: Name,
     resource_blends: DynArray<ResourceBlend>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct MorphPacketDA {
     size_capacity: u32,
     ptr: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct MorphPacket {
     unknown0_name: Name,
     unknown1_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct SkinSubSection {
     pub material_name: Name,
     bone_node_names: [Name; 7],
@@ -51,12 +52,12 @@ pub struct SkinSubSection {
     morph_packets: DynArray<MorphPacket>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct SkinSection {
     pub skin_sub_sections: DynArray<SkinSubSection>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct SkinBodyV1_291_03_06PC {
     pub mesh_names: DynArray<Name>,

--- a/bff/src/class/skin/v1_381_67_09_pc.rs
+++ b/bff/src/class/skin/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::{DynArray, ObjectLinkHeaderV1_381_67_09PC};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(bone_name_count: u32))]
 struct SkinSubsection {
     animation_node_names: [Name; 4],
@@ -15,14 +16,14 @@ struct SkinSubsection {
     bone_names: Vec<Name>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(bone_name_count: u32))]
 struct SkinSection {
     #[br(args(bone_name_count))]
     skin_subsections: DynArray<SkinSubsection>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct SkinBodyV1_381_67_09PC {
     mesh_names: DynArray<Name>,

--- a/bff/src/class/sound/generic.rs
+++ b/bff/src/class/sound/generic.rs
@@ -1,11 +1,14 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 
 use crate::class::trivial_class::TrivialClass;
 
 #[bitsize(16)]
-#[derive(DebugBits, Clone, BinRead, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    DebugBits, Clone, BinRead, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 pub struct SoundFlags {
     pub paused: u1,
     pub looping: u1,

--- a/bff/src/class/sound/v1_291_03_06_pc.rs
+++ b/bff/src/class/sound/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::{GenericClass, ReferencedNames};
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::{SoundFlags, SoundGeneric};
@@ -8,7 +9,15 @@ use crate::macros::trivial_class_generic::trivial_class_generic;
 use crate::traits::{Export, Import};
 
 #[derive(
-    Debug, Clone, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass,
+    Debug,
+    Clone,
+    BinRead,
+    Serialize,
+    BinWrite,
+    Deserialize,
+    ReferencedNames,
+    GenericClass,
+    JsonSchema,
 )]
 #[generic(name(SoundHeaderGeneric))]
 pub struct SoundHeader {
@@ -20,7 +29,9 @@ pub struct SoundHeader {
     flags: SoundFlags,
 }
 
-#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
+#[derive(
+    Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass, JsonSchema,
+)]
 #[br(import(link_header: &SoundHeader))]
 pub struct SoundBodyV1_291_03_06PC {
     #[br(count = link_header.data_size / 2)]

--- a/bff/src/class/sound/v1_381_67_09_pc.rs
+++ b/bff/src/class/sound/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::{GenericClass, ReferencedNames};
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::{SoundFlags, SoundGeneric};
@@ -9,7 +10,15 @@ use crate::names::Name;
 use crate::traits::{Export, Import};
 
 #[derive(
-    BinRead, Clone, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass,
+    BinRead,
+    Clone,
+    Debug,
+    Serialize,
+    BinWrite,
+    Deserialize,
+    ReferencedNames,
+    GenericClass,
+    JsonSchema,
 )]
 #[generic(name(SoundHeaderGeneric))]
 pub struct LinkHeader {
@@ -23,7 +32,9 @@ pub struct LinkHeader {
     pub flags: SoundFlags,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, GenericClass,
+)]
 #[br(import(link_header: &LinkHeader))]
 pub struct SoundBodyV1_381_67_09PC {
     #[br(count = link_header.data_size / 2)]

--- a/bff/src/class/spline/v1_06_63_02_pc.rs
+++ b/bff/src/class/spline/v1_06_63_02_pc.rs
@@ -1,18 +1,19 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{DynArray, ObjectLinkHeaderV1_06_63_02PC, Vec3f, Vec4f};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Segment {
     vertices: [Vec3f; 2],
     length: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Spline {
     point_id: [u16; 2],
     tangent_id: [u16; 2],
@@ -21,7 +22,7 @@ struct Spline {
     segments: [Segment; 8],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct SplineBodyV1_06_63_02PC {
     points: DynArray<Vec3f>,

--- a/bff/src/class/spline/v1_381_67_09_pc.rs
+++ b/bff/src/class/spline/v1_381_67_09_pc.rs
@@ -1,18 +1,19 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{DynArray, ObjectLinkHeaderV1_381_67_09PC, Vec3f, Vec4f};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SplineSegmentSubdivision {
     p: [Vec3f; 2],
     length: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SplineSegment {
     p: [u16; 2],
     t: [u16; 2],
@@ -21,7 +22,7 @@ struct SplineSegment {
     spline_segment_subdivisions: [SplineSegmentSubdivision; 8],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct SplineBodyV1_381_67_09PC {
     points: DynArray<Vec3f>,

--- a/bff/src/class/spline_graph/v1_381_67_09_pc.rs
+++ b/bff/src/class/spline_graph/v1_381_67_09_pc.rs
@@ -1,18 +1,19 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{DynArray, ObjectLinkHeaderV1_381_67_09PC, Vec3f, Vec4f};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SplineSegmentSubdivision {
     p: [Vec3f; 2],
     length: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SplineSegment {
     p: [u16; 2],
     t: [u16; 2],
@@ -21,7 +22,7 @@ struct SplineSegment {
     spline_segment_subdivisions: [SplineSegmentSubdivision; 8],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct SplineGraphBodyV1_381_67_09PC {
     points: DynArray<Vec3f>,

--- a/bff/src/class/surface/v1_06_63_02_pc.rs
+++ b/bff/src/class/surface/v1_06_63_02_pc.rs
@@ -1,6 +1,7 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -17,46 +18,46 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct PointsRelated0 {
     vec3: Vec3f,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct PointsRelated1 {
     vec4: Vec4f,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct MorpherRelated {
     data: [u8; 16],
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct MorphTargetDescRelated {
     data: [u8; 16],
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct MorphTargetDesc {
     name: u32,
     morph_target_desc_relateds: DynArray<MorphTargetDescRelated>,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct Morpher {
     morpher_relateds: DynArray<MorpherRelated>,
     morph_target_descs: DynArray<MorphTargetDesc>,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct Points {
     points_relateds0: DynArray<PointsRelated0>,
     points_relateds1: DynArray<PointsRelated1>,
     morpher: Morpher,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct PatchCol {
     sphere: Sphere,
     flag: u32,
@@ -65,7 +66,7 @@ struct PatchCol {
     cdcdcdcd: [u32; 2],
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct EdgeCol {
     sphere: Sphere,
     flag: u32,
@@ -74,7 +75,7 @@ struct EdgeCol {
     unk_placeholder_ptr3: u32,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct ClingLineRelated {
     sphere: Sphere,
     flag: u32,
@@ -83,12 +84,12 @@ struct ClingLineRelated {
     unk_float: f32,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct CullCone {
     data: [u8; 32],
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct Patch {
     flag: u16,
     should_draw_related_start_index: u16,
@@ -106,19 +107,19 @@ struct Patch {
     material_anim_name: Name,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct Edge {
     p: [u16; 2],
     t: [u16; 2],
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct SeadVoxel {
     element_entry: u16,
     element_count: u16,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 struct SeadIndex {
     sead_voxels: DynArray<SeadVoxel>,
     patch_indices: DynArray<u16>,
@@ -145,14 +146,16 @@ struct SeadIndex {
 }
 
 #[bitsize(16)]
-#[derive(BinRead, BinWrite, DebugBits, SerializeBits, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, BinWrite, DebugBits, SerializeBits, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct ShouldDrawRelated {
     index_in_draw_info_array: u3,
     shift_amount_for_bit: u5,
     other: u8,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct SurfaceBodyV1_06_63_02PC {
     points: Points,

--- a/bff/src/class/surface/v1_291_03_06_pc.rs
+++ b/bff/src/class/surface/v1_291_03_06_pc.rs
@@ -1,6 +1,7 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -18,34 +19,34 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct PointsRelated0 {
     vector: Vec3f,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct PointsRelated1 {
     vector: Vec4f,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Points {
     points_related0s: DynArray<PointsRelated0>,
     points_related1s: DynArray<PointsRelated1>,
     morpher: Morpher,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct MorpherRelated {
     data: [u8; 4],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Morpher {
     morpher_relateds: DynArray<MorpherRelated>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct EdgeCol {
     sphere: Sphere,
     flag: u32,
@@ -54,7 +55,7 @@ struct EdgeCol {
     edge_id: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct ClingLineRelated {
     sphere: Sphere,
     flag: u32,
@@ -64,17 +65,17 @@ struct ClingLineRelated {
     unknown2: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct CullCone {
     data: [u8; 32],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Box {
     transformation: Mat4f,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Patch {
     flag: u16,
     should_draw_related_start_index: u16,
@@ -92,21 +93,23 @@ struct Patch {
     material_anim_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Edge {
     p: [u16; 2],
     t: [u16; 2],
 }
 
 #[bitsize(16)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct ShouldDrawRelated {
     index_in_draw_info_array: u3,
     shift_amount_for_bit: u5,
     other: u8,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct PatchCol {
     sphere: Sphere,
     flag: u32,
@@ -115,13 +118,13 @@ struct PatchCol {
     cdcdcdcd: [u32; 2],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SeadVoxel {
     element_entry: u16,
     element_count: u16,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SeadIndex {
     sead_voxels: DynArray<SeadVoxel>,
     patch_indices: DynArray<u16>,
@@ -145,7 +148,7 @@ struct SeadIndex {
     hit_patch_count: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_06_63_02PC))]
 pub struct SurfaceBodyV1_291_03_06PC {
     points: Points,

--- a/bff/src/class/surface/v1_381_67_09_pc.rs
+++ b/bff/src/class/surface/v1_381_67_09_pc.rs
@@ -1,8 +1,8 @@
 use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{
@@ -18,17 +18,17 @@ use crate::helpers::{
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused2 {
     data: [u8; 32],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused3 {
     data: [u8; 32],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Patch {
     flag: u16,
     index_in_unk_short_da: u16,
@@ -42,40 +42,42 @@ struct Patch {
     material_anim_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Edge {
     p: [u16; 2],
     t: [u16; 2],
 }
 
 #[bitsize(16)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 struct ShouldDrawBitfield {
     index_in_draw_info_array: u3,
     shift_amount_for_bit: u5,
     other: u8,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unused12 {
     data: [u8; 32],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SeadVoxel {
     patches_indices_range: RangeBeginSize,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown15 {
-    #[serde(with = "BigArray")]
-    data: [u32; 48],
+    data1: [u32; 32],
+    data2: [u32; 16],
     sead_voxel_count: u32,
     patch_count_related: u32,
     unknown0s: [u32; 2],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SeadIndex {
     sead_voxels: DynArray<SeadVoxel>,
     patches_indices: DynArray<u16>,
@@ -83,7 +85,7 @@ struct SeadIndex {
     patch_count: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct SurfaceBodyV1_381_67_09PC {
     points: DynArray<Vec3f>,

--- a/bff/src/class/surface_datas/v1_381_67_09_pc.rs
+++ b/bff/src/class/surface_datas/v1_381_67_09_pc.rs
@@ -1,12 +1,13 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
 use crate::helpers::{ObjectDatasFlagsV1_381_67_09PC, ResourceObjectLinkHeaderV1_381_67_09PC};
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct SurfaceDatasBodyV1_381_67_09PC {
     flags: ObjectDatasFlagsV1_381_67_09PC,

--- a/bff/src/class/trivial_class.rs
+++ b/bff/src/class/trivial_class.rs
@@ -2,6 +2,7 @@ use std::io::{BufRead, Cursor};
 
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::BffError;
@@ -13,7 +14,7 @@ use crate::error::Error;
 use crate::names::Name;
 use crate::traits::TryFromVersionPlatform;
 
-#[derive(Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, ReferencedNames)]
 pub struct TrivialClass<LinkHeaderType, BodyType> {
     #[referenced_names(skip)]
     pub class_name: Name,

--- a/bff/src/class/user_define/v1_291_03_06_pc.rs
+++ b/bff/src/class/user_define/v1_291_03_06_pc.rs
@@ -3,18 +3,21 @@ use std::ffi::OsString;
 
 use bff_derive::{GenericClass, ReferencedNames};
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::generic::UserDefineGeneric;
 use crate::BffResult;
 use crate::class::trivial_class::TrivialClass;
 use crate::error::Error;
-use crate::helpers::{PascalString, ResourceObjectLinkHeaderV1_381_67_09PC};
+use crate::helpers::{PascalString, ResourceObjectLinkHeaderV1_06_63_02PC};
 use crate::macros::trivial_class_generic::trivial_class_generic;
 use crate::traits::{Artifact, Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames, GenericClass)]
-#[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
+#[derive(
+    BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames, GenericClass,
+)]
+#[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct UserDefineBodyV1_291_03_06PC {
     #[serde(skip)]
     #[generic]
@@ -22,7 +25,7 @@ pub struct UserDefineBodyV1_291_03_06PC {
 }
 
 pub type UserDefineV1_291_03_06PC =
-    TrivialClass<ResourceObjectLinkHeaderV1_381_67_09PC, UserDefineBodyV1_291_03_06PC>;
+    TrivialClass<ResourceObjectLinkHeaderV1_06_63_02PC, UserDefineBodyV1_291_03_06PC>;
 
 trivial_class_generic!(UserDefineV1_291_03_06PC, UserDefineGeneric);
 

--- a/bff/src/class/warp/v1_06_63_02_pc.rs
+++ b/bff/src/class/warp/v1_06_63_02_pc.rs
@@ -1,14 +1,15 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
-use crate::helpers::{DynArray, ResourceObjectLinkHeaderV1_381_67_09PC, Vec3f};
+use crate::helpers::{DynArray, ResourceObjectLinkHeaderV1_06_63_02PC, Vec3f};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
-#[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
+#[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct WarpBodyV1_06_63_02PC {
     flag: u32,
     vertices: [Vec3f; 8],
@@ -19,7 +20,7 @@ pub struct WarpBodyV1_06_63_02PC {
 }
 
 pub type WarpV1_06_63_02PC =
-    TrivialClass<ResourceObjectLinkHeaderV1_381_67_09PC, WarpBodyV1_06_63_02PC>;
+    TrivialClass<ResourceObjectLinkHeaderV1_06_63_02PC, WarpBodyV1_06_63_02PC>;
 
 impl Export for WarpV1_06_63_02PC {}
 impl Import for WarpV1_06_63_02PC {}

--- a/bff/src/class/world/v1_06_63_02_pc.rs
+++ b/bff/src/class/world/v1_06_63_02_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::{DynArray, ResourceObjectLinkHeaderV1_06_63_02PC, Vec2f};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SeadEntry {
     next_resource_of_entry: u32,
     prev_resource_of_entry: u32,
@@ -16,12 +17,12 @@ struct SeadEntry {
     node_name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct UnkStruct1 {
     data: [u8; 8],
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SeadHandle {
     p_min: Vec2f,
     p_max: Vec2f,
@@ -33,14 +34,14 @@ struct SeadHandle {
     sead_entries: DynArray<SeadEntry>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SubWorldRange {
     data: [u8; 24],
     unk_structs1: DynArray<UnkStruct1>,
     unk0: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct SubWorldData {
     data: [u8; 24],
     sub_world_range: SubWorldRange,
@@ -50,7 +51,7 @@ struct SubWorldData {
     unknown3s: DynArray<u32>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct WorldBodyV1_06_63_02PC {
     linked_names: DynArray<Name>,

--- a/bff/src/class/world/v1_291_03_06_pc.rs
+++ b/bff/src/class/world/v1_291_03_06_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::{DynArray, ResourceObjectLinkHeaderV1_06_63_02PC, Vec2f};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, JsonSchema)]
 struct SeadEntry {
     next_resource_of_entry: u32,
     prev_resource_of_entry: u32,
@@ -16,7 +17,7 @@ struct SeadEntry {
     node_name: Name,
 }
 
-#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, JsonSchema)]
 struct SeadHandle {
     p_min: Vec2f,
     p_max: Vec2f,
@@ -28,19 +29,19 @@ struct SeadHandle {
     sead_entries: DynArray<SeadEntry>,
 }
 
-#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, JsonSchema)]
 struct Unknown0 {
     data: [u8; 8],
 }
 
-#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, JsonSchema)]
 struct SubWorldRange {
     data: [u8; 24],
     unknown0s: DynArray<Unknown0>,
     unknown1: u32,
 }
 
-#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, JsonSchema)]
 struct SubWorldData {
     data: [u8; 24],
     sub_world_range: SubWorldRange,
@@ -50,7 +51,7 @@ struct SubWorldData {
     unknown3s: DynArray<u32>,
 }
 
-#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(Debug, BinRead, Serialize, BinWrite, Deserialize, ReferencedNames, JsonSchema)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_06_63_02PC))]
 pub struct WorldBodyV1_291_03_06PC {
     root_node_name: Name,

--- a/bff/src/class/world/v1_381_67_09_pc.rs
+++ b/bff/src/class/world/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,7 +8,7 @@ use crate::helpers::{DynArray, Mat4f, ResourceObjectLinkHeaderV1_381_67_09PC};
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct Unknown2 {
     placeholder0: u32,
     placeholder1: u32,
@@ -17,7 +18,7 @@ struct Unknown2 {
     zero: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ResourceObjectLinkHeaderV1_381_67_09PC))]
 pub struct WorldBodyV1_381_67_09PC {
     node_name0: Name,

--- a/bff/src/class/world_ref/v1_381_67_09_pc.rs
+++ b/bff/src/class/world_ref/v1_381_67_09_pc.rs
@@ -1,5 +1,6 @@
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::class::trivial_class::TrivialClass;
@@ -7,13 +8,13 @@ use crate::helpers::{DynArray, Mat4f, ObjectLinkHeaderV1_381_67_09PC, PascalStri
 use crate::names::Name;
 use crate::traits::{Export, Import};
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 struct UUIDPair {
     uuid0: u32,
     uuid1: u32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[br(import(_link_header: &ObjectLinkHeaderV1_381_67_09PC))]
 pub struct WorldRefBodyV1_381_67_09PC {
     node_name0: Name,

--- a/bff/src/helpers/dynarray.rs
+++ b/bff/src/helpers/dynarray.rs
@@ -4,10 +4,11 @@ use std::marker::PhantomData;
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite, binrw};
 use derive_more::{Deref, DerefMut};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[binrw]
-#[derive(Debug, Serialize, Deref, DerefMut, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deref, DerefMut, Deserialize, ReferencedNames, JsonSchema)]
 #[serde(transparent)]
 #[br(import_raw(inner: <InnerType as BinRead>::Args<'_>))]
 pub struct DynArray<InnerType: BinRead + BinWrite + 'static, SizeType: BinRead + BinWrite = u32>

--- a/bff/src/helpers/keyframer.rs
+++ b/bff/src/helpers/keyframer.rs
@@ -2,6 +2,7 @@ use std::io::Seek;
 
 use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite, binread};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -22,7 +23,7 @@ use crate::names::Name;
 type Key = f32;
 
 #[binread]
-#[derive(Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 #[br(stream = s)]
 pub struct KeyTgtTpl<T>
 where
@@ -78,7 +79,7 @@ where
 }
 
 #[binread]
-#[derive(Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 #[br(stream = s)]
 pub struct KeyLinearTpl<T>
 where
@@ -129,7 +130,7 @@ where
     }
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[brw(repr = u16)]
 pub enum KeyframerInterpolationType {
     Smooth = 1,
@@ -140,7 +141,7 @@ pub enum KeyframerInterpolationType {
     Unknown17 = 17, // unknown1 in Rtc's RtcAnimationNode uses this
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 pub struct KeyframerTpl<TKey>
 where
     for<'a> TKey: BinRead + BinWrite + Serialize + 'a,
@@ -151,7 +152,7 @@ where
     keyframes: DynArray<TKey>,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 pub struct KeyframerNoFlagsTpl<TKey>
 where
     for<'a> TKey: BinRead + BinWrite + Serialize + 'a,
@@ -161,7 +162,7 @@ where
     keyframes: DynArray<TKey>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct Message {
     message_class: u32,
     reciever_name: Name,

--- a/bff/src/helpers/link_header.rs
+++ b/bff/src/helpers/link_header.rs
@@ -2,13 +2,14 @@ use bff_derive::ReferencedNames;
 use bilge::prelude::*;
 use binrw::helpers::until_eof;
 use binrw::{BinRead, BinWrite};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::{DynArray, Mat4f, Quat};
+use super::{BffBox, DynArray, Sphere};
 use crate::names::Name;
 use crate::traits::TryFromGenericSubstitute;
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct ResourceObjectLinkHeaderV1_381_67_09PC {
     #[referenced_names(skip)]
     link_name: Name,
@@ -23,7 +24,9 @@ impl TryFromGenericSubstitute<Self, Self> for ResourceObjectLinkHeaderV1_381_67_
 }
 
 #[bitsize(32)]
-#[derive(BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames)]
+#[derive(
+    BinRead, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames, JsonSchema,
+)]
 pub struct ObjectDatasFlagsV1_381_67_09PC {
     hide: u1,
     code_control: u1,
@@ -43,7 +46,14 @@ pub struct ObjectDatasFlagsV1_381_67_09PC {
 
 #[bitsize(32)]
 #[derive(
-    BinRead, FromBits, DebugBits, SerializeBits, BinWrite, DeserializeBits, ReferencedNames,
+    BinRead,
+    FromBits,
+    DebugBits,
+    SerializeBits,
+    BinWrite,
+    DeserializeBits,
+    ReferencedNames,
+    JsonSchema,
 )]
 pub struct ObjectFlagsV1_381_67_09PC {
     init: u1,
@@ -66,7 +76,7 @@ pub struct ObjectFlagsV1_381_67_09PC {
     padding: u15,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 #[brw(repr = u16)]
 pub enum ObjectType {
     Points = 0,
@@ -97,19 +107,19 @@ pub enum ObjectType {
     WorldRef = 26,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct ObjectLinkHeaderV1_381_67_09PC {
     #[referenced_names(skip)]
     link_name: Name,
     data_name: Name,
-    rot: Quat,
-    transform: Mat4f,
-    radius: f32,
+    b_sphere: Sphere,
+    b_box: BffBox,
+    fade_out_dist: f32,
     flags: ObjectFlagsV1_381_67_09PC,
     r#type: ObjectType,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct ResourceObjectLinkHeaderV1_06_63_02PC {
     #[referenced_names(skip)]
     link_name: Name,
@@ -126,15 +136,15 @@ impl TryFromGenericSubstitute<Self, Self> for ResourceObjectLinkHeaderV1_06_63_0
     }
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct ObjectLinkHeaderV1_06_63_02PC {
     #[referenced_names(skip)]
     link_name: Name,
     names: DynArray<Name>,
     data_name: Name,
-    rot: Quat,
-    transform: Mat4f,
-    radius: f32,
+    b_sphere: Sphere,
+    b_box: BffBox,
+    fade_out_dist: f32,
     pub flags: u32,
     r#type: ObjectType,
 }
@@ -213,9 +223,9 @@ pub struct ObjectLinkHeaderGeneric {
     pub link_name: Name,
     pub names: DynArray<Name>,
     pub data_name: Name,
-    pub rot: Quat,
-    pub transform: Mat4f,
-    pub radius: f32,
+    pub b_sphere: Sphere,
+    pub b_box: BffBox,
+    pub fade_out_dist: f32,
     pub flags: u32,
     pub r#type: ObjectType,
 }
@@ -226,9 +236,9 @@ impl From<ObjectLinkHeaderV1_381_67_09PC> for ObjectLinkHeaderGeneric {
             link_name: header.link_name,
             names: vec![].into(),
             data_name: header.data_name,
-            rot: header.rot,
-            transform: header.transform,
-            radius: header.radius,
+            b_sphere: header.b_sphere,
+            b_box: header.b_box,
+            fade_out_dist: header.fade_out_dist,
             flags: header.flags.value,
             r#type: header.r#type,
         }
@@ -241,9 +251,9 @@ impl From<ObjectLinkHeaderV1_06_63_02PC> for ObjectLinkHeaderGeneric {
             link_name: header.link_name,
             names: header.names,
             data_name: header.data_name,
-            rot: header.rot,
-            transform: header.transform,
-            radius: header.radius,
+            b_sphere: header.b_sphere,
+            b_box: header.b_box,
+            fade_out_dist: header.fade_out_dist,
             flags: header.flags,
             r#type: header.r#type,
         }
@@ -255,9 +265,9 @@ impl From<ObjectLinkHeaderGeneric> for ObjectLinkHeaderV1_381_67_09PC {
         Self {
             link_name: header.link_name,
             data_name: header.data_name,
-            rot: header.rot,
-            transform: header.transform,
-            radius: header.radius,
+            b_sphere: header.b_sphere,
+            b_box: header.b_box,
+            fade_out_dist: header.fade_out_dist,
             flags: ObjectFlagsV1_381_67_09PC::from(header.flags),
             r#type: header.r#type,
         }
@@ -270,9 +280,9 @@ impl From<ObjectLinkHeaderGeneric> for ObjectLinkHeaderV1_06_63_02PC {
             link_name: header.link_name,
             names: header.names,
             data_name: header.data_name,
-            rot: header.rot,
-            transform: header.transform,
-            radius: header.radius,
+            b_sphere: header.b_sphere,
+            b_box: header.b_box,
+            fade_out_dist: header.fade_out_dist,
             flags: header.flags,
             r#type: header.r#type,
         }

--- a/bff/src/helpers/map.rs
+++ b/bff/src/helpers/map.rs
@@ -6,9 +6,10 @@ use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinResult, BinWrite, Endian};
 use derive_more::Deref;
 use indexmap::IndexMap;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deref, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deref, Deserialize, JsonSchema, ReferencedNames)]
 #[serde(transparent)]
 pub struct BffMap<KeyType: Eq + Hash, ValueType, SizeType = u32> {
     #[deref]

--- a/bff/src/helpers/math.rs
+++ b/bff/src/helpers/math.rs
@@ -5,6 +5,7 @@ use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite, binrw};
 use derive_more::{Deref, DerefMut};
 use num_traits::{CheckedAdd, Float, NumCast, PrimInt, Signed, Unsigned, cast};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::names::Name;
@@ -30,7 +31,9 @@ pub type Mat4f = Mat<4>;
 pub type Mat3x4f = Mat<3, 4>;
 
 // A fixed precision float with a variable numerator and constant denominator.
-#[derive(BinRead, BinWrite, Deref, DerefMut, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(
+    BinRead, BinWrite, Deref, DerefMut, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema,
+)]
 #[serde(transparent)]
 pub struct NumeratorFloat<
     T: NumCast + BinRead + BinWrite,
@@ -49,7 +52,9 @@ where
     for<'a> T: BinWrite<Args<'a> = ()>;
 
 // A fixed precision normal float between -1 and 1. (x / x.max_value()) * 2 + -1.
-#[derive(BinRead, BinWrite, Deref, DerefMut, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(
+    BinRead, BinWrite, Deref, DerefMut, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema,
+)]
 #[serde(transparent)]
 pub struct SignedNormalFloat<
     T: NumCast + Div<F, Output = F> + Unsigned + PrimInt + BinRead + BinWrite,
@@ -70,7 +75,7 @@ where
 // We intentionally use the names first and last instead of begin and end to avoid confusion with
 // C++ iterators.
 #[binrw]
-#[derive(Debug, Serialize, Deref, DerefMut, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deref, DerefMut, Deserialize, ReferencedNames, JsonSchema)]
 #[serde(rename = "range_inclusive")]
 pub struct RangeFirstLast<T = u16>
 where
@@ -91,7 +96,7 @@ where
 
 // Range whose first element is first and contains size elements. [first, first + size).
 #[binrw]
-#[derive(Debug, Serialize, Deref, DerefMut, Deserialize, ReferencedNames)]
+#[derive(Debug, Serialize, Deref, DerefMut, Deserialize, ReferencedNames, JsonSchema)]
 #[serde(rename = "range")]
 pub struct RangeBeginSize<T = u16>
 where
@@ -110,34 +115,48 @@ where
     inner: Range<T>,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct Sphere {
     pub center: Vec3f,
     pub radius: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct BffBox {
     pub matrix: Mat3x4f,
     pub vec: Vec3f,
     pub scale: f32,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
+pub struct Segment {
+    pub origin: Vec3f,
+    pub length: f32,
+    pub direction: Vec3f,
+    pub pad: f32,
+}
+
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
+pub struct Cylindre {
+    pub seg: Segment,
+    pub radius: f32,
+}
+
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct DynSphere {
     pub sphere: Sphere,
     pub flags: u32,
     pub name: Name,
 }
 
-#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, ReferencedNames)]
+#[derive(BinRead, Debug, Serialize, BinWrite, Deserialize, JsonSchema, ReferencedNames)]
 pub struct DynBox {
     pub matrix: Mat4f,
     pub flags: u32,
     pub name: Name,
 }
 
-#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames)]
+#[derive(BinRead, BinWrite, Debug, Serialize, Deserialize, ReferencedNames, JsonSchema)]
 pub struct Rect<T: BinRead + BinWrite + 'static = i32>
 where
     for<'a> <T as BinRead>::Args<'a>: Default + Clone,

--- a/bff/src/helpers/option.rs
+++ b/bff/src/helpers/option.rs
@@ -5,10 +5,11 @@ use bff_derive::ReferencedNames;
 use binrw::{BinRead, BinWrite, binrw};
 use derive_more::Deref;
 use num_traits::{One, Zero};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[binrw]
-#[derive(Serialize, Deref, Debug, Deserialize, ReferencedNames)]
+#[derive(Serialize, Deref, Debug, Deserialize, ReferencedNames, JsonSchema)]
 pub struct BffOption<
     InnerType: BinRead + BinWrite,
     ConditionType: BinRead + BinWrite + One + Zero + Eq = u8,

--- a/bff/src/helpers/strings.rs
+++ b/bff/src/helpers/strings.rs
@@ -8,6 +8,7 @@ use binrw::io::{Read, Seek};
 use binrw::meta::{EndianKind, ReadEndian, WriteEndian};
 use binrw::{BinRead, BinResult, BinWrite, BinWriterExt, Endian, Error, NullString, args};
 use derive_more::{Constructor, Deref, DerefMut, Display, Error, From, Into};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::copy_repeat;
@@ -27,6 +28,7 @@ use super::copy_repeat;
     Hash,
     Deserialize,
     ReferencedNames,
+    JsonSchema,
 )]
 #[serde(transparent)]
 pub struct FixedStringNull<const S: usize>(pub String);
@@ -116,6 +118,7 @@ impl<const S: usize> BinWrite for FixedStringNull<S> {
     Serialize,
     Deserialize,
     ReferencedNames,
+    JsonSchema,
 )]
 #[display("{}", string)]
 #[serde(transparent)]
@@ -234,6 +237,7 @@ where
     Hash,
     Deserialize,
     ReferencedNames,
+    JsonSchema,
 )]
 #[serde(transparent)]
 pub struct PascalStringNull(pub String);
@@ -302,6 +306,7 @@ impl BinWrite for PascalStringNull {
     Hash,
     Deserialize,
     ReferencedNames,
+    JsonSchema,
 )]
 #[serde(transparent)]
 pub struct StringUntilNull(pub String);

--- a/bff/src/macros/bff_class.rs
+++ b/bff/src/macros/bff_class.rs
@@ -74,6 +74,26 @@ macro_rules! bff_class {
             }
         }
 
+        impl schemars::JsonSchema for $class {
+            fn inline_schema() -> bool {
+                true
+            }
+
+            fn schema_name() -> std::borrow::Cow<'static, str> {
+                stringify!($class).into()
+            }
+
+            fn schema_id() -> std::borrow::Cow<'static, str> {
+                format!("{}::{}", module_path!(), stringify!($class)).into()
+            }
+
+            fn json_schema(_schema_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                schemars::json_schema!({
+                    "type": "object"
+                })
+            }
+        }
+
         pastey::paste! {
             #[allow(non_snake_case)]
             #[derive(Default, Clone, Copy, Debug)]
@@ -98,7 +118,7 @@ macro_rules! bff_class {
         }
     };
     ($class:ident { $($pattern:pat => $variant:ident),* $(,)? }) => {
-        #[derive(serde::Serialize, serde::Deserialize, Debug, derive_more::From, derive_more::IsVariant, bff_derive::ReferencedNames)]
+        #[derive(serde::Serialize, serde::Deserialize, Debug, derive_more::From, derive_more::IsVariant, bff_derive::ReferencedNames, schemars::JsonSchema)]
         pub enum $class {
             $($variant(std::boxed::Box<$variant>)),*
         }

--- a/bff/src/macros/classes.rs
+++ b/bff/src/macros/classes.rs
@@ -1,11 +1,11 @@
 macro_rules! classes {
     ($($class:ident),* $(,)?) => {
-        #[derive(serde::Serialize, Debug, derive_more::From, derive_more::IsVariant, serde::Deserialize, bff_derive::ReferencedNames)]
+        #[derive(serde::Serialize, Debug, derive_more::From, derive_more::IsVariant, serde::Deserialize, bff_derive::ReferencedNames, schemars::JsonSchema)]
         pub enum Class {
             $($class($class),)*
         }
 
-        #[derive(serde::Serialize, Debug, serde::Deserialize)]
+        #[derive(serde::Serialize, Debug, serde::Deserialize, schemars::JsonSchema)]
         pub enum ClassType {
             $($class,)*
         }

--- a/bff/src/macros/platforms.rs
+++ b/bff/src/macros/platforms.rs
@@ -59,12 +59,12 @@ macro_rules! platforms {
             $($platform:ident($styles:tt,$endian:ident)),* $(,)?
         ]
     ) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, serde::Serialize, serde::Deserialize, derive_more::FromStr)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, serde::Serialize, serde::Deserialize, derive_more::FromStr, schemars::JsonSchema)]
         pub enum Style {
             $($style,)*
         }
 
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, serde::Serialize, serde::Deserialize, derive_more::FromStr, binrw::BinRead, binrw::BinWrite)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, serde::Serialize, serde::Deserialize, derive_more::FromStr, binrw::BinRead, binrw::BinWrite, schemars::JsonSchema)]
         #[brw(repr = u8)]
         pub enum Platform {
             $($platform,)*

--- a/bff/src/names/mod.rs
+++ b/bff/src/names/mod.rs
@@ -1,5 +1,6 @@
 mod wordlist;
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter, Write as _};
@@ -14,6 +15,7 @@ use derive_more::{Display, From};
 use encoding_rs::WINDOWS_1252;
 use num_traits::AsPrimitive;
 use once_cell::sync::Lazy;
+use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
 use serde::{Deserialize, Deserializer, Serialize};
 use string_interner::backend::BucketBackend;
 use string_interner::{DefaultSymbol, StringInterner};
@@ -244,7 +246,7 @@ pub enum NameType {
     Ubisoft64,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 enum SerdeName<'a, T> {
     Name(T),
@@ -394,6 +396,26 @@ impl<'de> Deserialize<'de> for Name {
                 }
             }
         }
+    }
+}
+
+impl JsonSchema for Name {
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn schema_name() -> Cow<'static, str> {
+        "Name".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        concat!(module_path!(), "::Name").into()
+    }
+
+    fn json_schema(_schema_generator: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": ["string", "integer"]
+        })
     }
 }
 


### PR DESCRIPTION
Added support for generating a json schema file for the types that can get serialized/deserialized to/from json. Also some minor changes to existing types and QoL stuff like creating the whole path on BF extract. Ran cargo fmt, sorry 🥺